### PR TITLE
Add support for Shattrath portal

### DIFF
--- a/Config.lua
+++ b/Config.lua
@@ -97,7 +97,7 @@ Config.currentTraderRealm = nil
 Config.currentTraderMoney = nil
 Config.Portals = {"Portal: Darnassus", "Portal: Stormwind", "Portal: Ironforge", "Portal: Orgrimmar",
                   "Portal: Thunder Bluff", "Portal: Undercity", "Portal: Exodar", "Portal: Theramore",
-                  "Portal: Silvermoon", "Portal: Stonard"}
+                  "Portal: Silvermoon", "Portal: Stonard", "Portal: Shattrath"}
 -- List of currently alive portals
 Config.CurrentAlivePortals = {}
 

--- a/Utils.lua
+++ b/Utils.lua
@@ -249,6 +249,14 @@ function Utils.getMatchingPortal(destination)
             spellID = 32267
         elseif bestMatch == "Portal: Stonard" then
             spellID = 49361
+        elseif bestMatch == "Portal: Shattrath" then
+            -- Both Alliance and Horde can portal to Shattrath, but they have different spell IDs, so we need to check the player's faction first
+            local englishFaction, _ = UnitFactionGroup("player")
+            if englishFaction == "Alliance" then
+                spellID = 33691
+            elseif englishFaction == "Horde" then
+                spellID = 35717
+            end
         end
 
         portal = {


### PR DESCRIPTION
I noticed in a comment on CurseForge that someone mentioned they did not get the icon/button for Shattrath pop up. It indeed looks like this one has not yet been added and it's one of the more popular destinations in TBC Anniversary.

I added the portal spell IDs (since they [differ per faction](https://www.wowhead.com/tbc/spells/name:Portal:+Shattrath)) to the `Utils.getMatchingPortal()` function.

I currently don't have any mages that are a high enough level to have the Shattrath portal, so **I have not been able to personally test this!**