### PR TITLE
Add Utils.print and Utils.debugPrint

### DIFF
--- a/Events.lua
+++ b/Events.lua
@@ -23,8 +23,8 @@ Events.uiInitialized = false -- Flag to track if UI has been created
 -- }
 
 local function printEvent(event)
-    if Config.Settings and Config.Settings.debugMode then
-        print("|cff87CEEB[Thic-Portals]|r " .. event .. " event fired.")
+    if Config.Settings then
+        Utils.debugPrint(event .. " event fired.")
     end
 end
 
@@ -37,14 +37,14 @@ function Events.initializeUI()
     -- Final verification that spellbook is readable
     local testSpell = GetSpellBookItemName(1, BOOKTYPE_SPELL)
     if not testSpell then
-        print("|cff87CEEB[Thic-Portals]|r ERROR: Cannot initialize - spellbook not accessible!")
+        Utils.print("ERROR: Cannot initialize - spellbook not accessible!")
         return
     end
 
     -- Mark as initialized
     Events.uiInitialized = true
 
-    print("|cff87CEEB[Thic-Portals]|r Initializing UI with spellbook loaded...")
+    Utils.print("Initializing UI with spellbook loaded...")
 
     -- Print gold info to the console
     Utils.printGoldInformation()
@@ -59,18 +59,17 @@ function Events.initializeUI()
     -- Create the global interface options panel
     UI.createInterfaceOptionsPanel()
 
-    print("|cff87CEEB[Thic-Portals]|r UI initialization complete!")
+    Utils.print("UI initialization complete!")
 end
 
 -- Function to handle consecutive leaves without payment
 local function handleConsecutiveLeavesWithoutPayment()
     Config.Settings.consecutiveLeavesWithoutPayment = Config.Settings.consecutiveLeavesWithoutPayment + 1
-    print("|cff87CEEB[Thic-Portals]|r Consecutive players who have left the party without payment: " ..
+    Utils.print("Consecutive players who have left the party without payment: " ..
               Config.Settings.consecutiveLeavesWithoutPayment)
 
     if Config.Settings.consecutiveLeavesWithoutPayment >= Config.Settings.leaveWithoutPaymentThreshold then
-        print(
-            "|cff87CEEB[Thic-Portals]|r Two people in a row left without payment - you are likely AFK. Shutting down the addon.")
+        Utils.print("Two people in a row left without payment - you are likely AFK. Shutting down the addon.")
         if Config.Settings.addonEnabled then
             UI.toggleAddonEnabledState()
         end
@@ -107,7 +106,7 @@ function Events.onEvent(self, event, ...)
                 local testSpell = GetSpellBookItemName(1, BOOKTYPE_SPELL)
                 if not testSpell then
                     -- Spellbook still not ready, try again with longer delay
-                    print("|cff87CEEB[Thic-Portals]|r Spellbook not ready yet, waiting...")
+                    Utils.print("Spellbook not ready yet, waiting...")
                     C_Timer.After(3, function()
                         Events.initializeUI()
                     end)
@@ -132,9 +131,7 @@ function Events.onEvent(self, event, ...)
         if not Config.Settings.disableGlobalChannels then
             checkGlobal = true
         else
-            if Config.Settings.debugMode then
-                print("|cff87CEEB[Thic-Portals]|r Global channels disabled. Skipping global channel message.")
-            end
+            Utils.debugPrint("Global channels disabled. Skipping global channel message.")
         end
     end
 
@@ -153,9 +150,7 @@ function Events.onEvent(self, event, ...)
             if message and name then
                 -- If name is not "Thicfury" or "Thic", return
                 -- if not (name == "Thicfury" or name == "Thic") then
-                --     if Config.Settings.debugMode then
-                --         print("|cff87CEEB[Thic-Portals]|r Ignoring message from: " .. name)
-                --     end
+                --     Utils.debugPrint("Ignoring message from: " .. name)
                 --     return
                 -- end
 
@@ -208,10 +203,7 @@ function Events.onEvent(self, event, ...)
                 inviteData.ticketFrame:Hide()
             end
             Events.pendingInvites[sender] = nil
-            if Config.Settings.debugMode then
-                print("|cff87CEEB[Thic-Portals]|r " .. sender ..
-                          " has left the party and has been removed from tracking.")
-            end
+            Utils.debugPrint(sender .. " has left the party and has been removed from tracking.")
             if not (inviteData and inviteData.hasPaid) and not Config.Settings.disableAFKProtection then
                 handleConsecutiveLeavesWithoutPayment()
             end
@@ -261,9 +253,7 @@ function Events.onEvent(self, event, ...)
             local spellName = GetSpellInfo(spellID)
             for _, portalName in ipairs(Config.Portals) do
                 if spellName:lower() == portalName:lower() then
-                    if Config.Settings.debugMode then
-                        print("|cff87CEEB[Thic-Portals]|r Portal to " .. spellName .. " successfully cast!")
-                    end
+                    Utils.debugPrint("Portal to " .. spellName .. " successfully cast!")
 
                     Config.CurrentAlivePortals[spellName] = true
 
@@ -278,10 +268,8 @@ function Events.onEvent(self, event, ...)
                     C_Timer.After(60, function()
                         Config.CurrentAlivePortals[spellName] = nil
 
-                        if Config.Settings.debugMode then
-                            print("|cff87CEEB[Thic-Portals]|r Portal to " .. spellName ..
-                                      " has been removed from the list of active portals.")
-                        end
+                        Utils.debugPrint("Portal to " .. spellName ..
+                                    " has been removed from the list of active portals.")
                     end)
 
                     break
@@ -311,9 +299,7 @@ function Events.onEvent(self, event, ...)
                 for sender, inviteData in pairs(Events.pendingInvites) do
                     if inviteData.name == targetName then
                         inviteData.targetted = true
-                        if Config.Settings.debugMode then
-                            print("|cff87CEEB[Thic-Portals]|r Target set to: " .. targetName)
-                        end
+                        Utils.debugPrint("Target set to: " .. targetName)
 
                         break
                     end
@@ -330,25 +316,19 @@ end
 -- Function to reset the consecutive leaves without payment counter
 function Events.resetConsecutiveLeavesWithoutPaymentCounter()
     Config.Settings.consecutiveLeavesWithoutPayment = 0
-    if Config.Settings.debugMode then
-        print("|cff87CEEB[Thic-Portals]|r Trade initiated. Resetting consecutive leaves without payment counter.")
-    end
+    Utils.debugPrint("Trade initiated. Resetting consecutive leaves without payment counter.")
 end
 
 -- Function to store the current trader's information
 function Events.storeCurrentTrader()
     Config.currentTraderName, Config.currentTraderRealm = UnitName("NPC", true)
-    if Config.Settings.debugMode then
-        print("|cff87CEEB[Thic-Portals]|r Current trader: " .. (Config.currentTraderName or "Unknown"))
-    end
+    Utils.debugPrint("Current trader: " .. (Config.currentTraderName or "Unknown"))
 end
 
 -- Function to update trade money
 function Events.updateTradeMoney()
     Config.currentTraderMoney = GetTargetTradeMoney()
-    if Config.Settings.debugMode then
-        print("|cff87CEEB[Thic-Portals]|r Current trade money: " .. (Config.currentTraderMoney or "Unknown"))
-    end
+    Utils.debugPrint("Current trade money: " .. (Config.currentTraderMoney or "Unknown"))
 end
 
 -- Function to handle trade completion
@@ -371,12 +351,10 @@ function Events.handleTradeComplete()
             Config.currentTraderMoney = nil
             Config.currentTraderRealm = nil
         else
-            if Config.Settings.debugMode then
-                print("|cff87CEEB[Thic-Portals]|r No pending invite found for current trader, ignoring transaction.")
-            end
+            Utils.debugPrint("No pending invite found for current trader, ignoring transaction.")
         end
-    elseif Config.Settings.debugMode then
-        print("|cff87CEEB[Thic-Portals]|r No current trader found.")
+    else
+        Utils.debugPrint("No current trader found.")
     end
 end
 

--- a/InviteTrade.lua
+++ b/InviteTrade.lua
@@ -49,7 +49,7 @@ local function updatePendingInviteDestination(playerName, message)
             Events.pendingInvites[playerName].destinationValue:SetText(destinationKeyword)
         end
 
-        print("|cff87CEEB[Thic-Portals]|r Updated destination for " .. playerName .. " to " .. destinationKeyword)
+        Utils.print("Updated destination for " .. playerName .. " to " .. destinationKeyword)
 
         if Events.pendingInvites[playerName].actionButton then
             -- Set the icon texture for the portal spell
@@ -74,7 +74,7 @@ function InviteTrade.invitePlayer(sender)
 
     playMatchSound()
 
-    print("|cff87CEEB[Thic-Portals]|r Invited " .. sender .. " to the group.")
+    Utils.print("Invited " .. sender .. " to the group.")
 end
 
 -- Function to create a pending invite entry
@@ -100,14 +100,12 @@ function InviteTrade.handleCommonPhraseInvite(message)
     local destinationPosition, destinationKeyword = Utils.findKeywordPosition(message,
         Config.Settings.DestinationKeywords)
 
-    if Config.Settings.debugMode then
-        if phrase then
-            print("|cff87CEEB[Thic-Portals]|r [Common-phrase-invite] Matched on common phrase: " .. phrase)
-            print("|cff87CEEB[Thic-Portals]|r [Common-phrase-invite] Destination keyword: " ..
-                      (destinationKeyword or "none"))
-        else
-            print("|cff87CEEB[Thic-Portals]|r [Common-phrase-invite] Failed to match via common phrase")
-        end
+    if phrase then
+        Utils.debugPrint("[Common-phrase-invite] Matched on common phrase: " .. phrase)
+        Utils.debugPrint("[Common-phrase-invite] Destination keyword: " ..
+                    (destinationKeyword or "none"))
+    else
+        Utils.debugPrint("[Common-phrase-invite] Failed to match via common phrase")
     end
 
     return phrase, destinationKeyword
@@ -118,13 +116,11 @@ function InviteTrade.handleDestinationOnlyInvite(message)
     local destinationPosition, destinationKeyword = Utils.findKeywordPosition(message,
         Config.Settings.DestinationKeywords)
 
-    if Config.Settings.debugMode then
-        if destinationPosition then
-            print("|cff87CEEB[Thic-Portals]|r [Destination-only-invite] Matched on destination keyword: " ..
-                      destinationKeyword)
-        else
-            print("|cff87CEEB[Thic-Portals]|r [Destination-only-invite] Failed to match via destination keyword")
-        end
+    if destinationPosition then
+        Utils.debugPrint("[Destination-only-invite] Matched on destination keyword: " ..
+                    destinationKeyword)
+    else
+        Utils.debugPrint("[Destination-only-invite] Failed to match via destination keyword")
     end
 
     local matched = destinationPosition and true or false
@@ -139,10 +135,8 @@ function InviteTrade.handleAdvancedKeywordInvite(message)
 
     local intentPosition, intentKeyword = Utils.findKeywordPosition(message, Config.Settings.IntentKeywords)
     if intentPosition then
-        if Config.Settings.debugMode then
-            print("|cff87CEEB[Thic-Portals]|r [Advanced-keyword-invite] Matched on intent keyword: " .. intentKeyword ..
-                      " (position: " .. intentPosition .. ")")
-        end
+        Utils.debugPrint("[Advanced-keyword-invite] Matched on intent keyword: " .. intentKeyword ..
+                    " (position: " .. intentPosition .. ")")
 
         local servicePosition, serviceKeyword = Utils.findKeywordPosition(message, Config.Settings.ServiceKeywords)
         local destinationPosition, destKeyword = Utils.findKeywordPosition(message, Config.Settings.DestinationKeywords)
@@ -151,29 +145,20 @@ function InviteTrade.handleAdvancedKeywordInvite(message)
             matched = true
             destinationKeyword = destKeyword
 
-            if Config.Settings.debugMode then
-                print("|cff87CEEB[Thic-Portals]|r [Advanced-keyword-invite] Matched on service keyword: " ..
-                          serviceKeyword .. " (position: " .. servicePosition .. ")")
+            Utils.debugPrint("[Advanced-keyword-invite] Matched on service keyword: " ..
+                        serviceKeyword .. " (position: " .. servicePosition .. ")")
 
-                if destinationPosition then
-                    print("|cff87CEEB[Thic-Portals]|r [Advanced-keyword-invite] Matched on destination keyword: " ..
-                              destKeyword .. " (position: " .. destinationPosition .. ")")
-                else
-                    print(
-                        "|cff87CEEB[Thic-Portals]|r [Advanced-keyword-invite] Failed to match via advanced keyword matching - no destination keyword found.")
-                end
+            if destinationPosition then
+                Utils.debugPrint("[Advanced-keyword-invite] Matched on destination keyword: " ..
+                            destKeyword .. " (position: " .. destinationPosition .. ")")
+            else
+                Utils.debugPrint("[Advanced-keyword-invite] Failed to match via advanced keyword matching - no destination keyword found.")
             end
         else
-            if Config.Settings.debugMode then
-                print(
-                    "|cff87CEEB[Thic-Portals]|r [Advanced-keyword-invite] Failed to match via advanced keyword matching - no service keyword found.")
-            end
+            Utils.debugPrint("[Advanced-keyword-invite] Failed to match via advanced keyword matching - no service keyword found.")
         end
     else
-        if Config.Settings.debugMode then
-            print(
-                "|cff87CEEB[Thic-Portals]|r [Advanced-keyword-invite] Failed to match via advanced keyword matching - no intent keyword found.")
-        end
+        Utils.debugPrint("[Advanced-keyword-invite] Failed to match via advanced keyword matching - no intent keyword found.")
     end
 
     return matched, destinationKeyword
@@ -190,33 +175,26 @@ function InviteTrade.handleInviteAndMessage(sender, playerName, playerClass, mes
     end
 
     if currentTicketCount >= Config.Settings.maxSimultaneousTickets then
-        if Config.Settings.debugMode then
-            print("[Thic-Portals] Maximum simultaneous tickets (" .. Config.Settings.maxSimultaneousTickets ..
-                      ") reached. Ignoring invite for: " .. playerName)
-        end
+        Utils.debugPrint("Maximum simultaneous tickets (" .. Config.Settings.maxSimultaneousTickets ..
+                    ") reached. Ignoring invite for: " .. playerName)
         return
     end
 
     -- Here we deal with the player ban list
     if Utils.isPlayerBanned(sender) then
-        if Config.Settings.debugMode then
-            print("|cff87CEEB[Thic-Portals]|r Player " .. sender .. " is on the ban list. No invite sent.")
-        end
+        Utils.debugPrint("Player " .. sender .. " is on the ban list. No invite sent.")
         return
     end
 
     -- Here we deal with the keyword ban list
     if Utils.messageHasPhraseOrKeyword(message, Config.Settings.KeywordBanList) then
-        -- If debug mode
-        if Config.Settings.debugMode then
-            print("|cff87CEEB[Thic-Portals]|r Player " .. sender .. " used a banned keyword. No invite sent.")
-        end
+        Utils.debugPrint("Player " .. sender .. " used a banned keyword. No invite sent.")
         return
     end
 
     -- Here we deal with potential invite cooldowns, this should only return early if the player hasn't joined yet
     if stillOnCooldown(playerName) then
-        print("|cff87CEEB[Thic-Portals]|r Player " .. sender .. " is still on invite cooldown.")
+        Utils.print("Player " .. sender .. " is still on invite cooldown.")
         return
     end
 
@@ -233,10 +211,8 @@ function InviteTrade.handleInviteAndMessage(sender, playerName, playerClass, mes
 
     if matched then
         if Config.Settings.requireDestination and not destinationKeyword then
-            if Config.Settings.debugMode then
-                print("|cff87CEEB[Thic-Portals]|r Invite match found from " .. playerName ..
-                          ", but no (valid) destination keyword detected and Require Destination is enabled. Not sending invite.")
-            end
+            Utils.debugPrint("Invite match found from " .. playerName ..
+                        ", but no (valid) destination keyword detected and Require Destination is enabled. Not sending invite.")
             return
         end
         InviteTrade.invitePlayer(sender)
@@ -251,7 +227,7 @@ end
 function InviteTrade.setSenderExpiryTimer(playerName)
     C_Timer.After(180, function()
         if Events.pendingInvites[playerName] then
-            print("|cff87CEEB[Thic-Portals]|r Invite for " .. playerName .. " expired.")
+            Utils.print("Invite for " .. playerName .. " expired.")
             Events.pendingInvites[playerName] = nil
         end
     end)
@@ -271,14 +247,12 @@ function InviteTrade.watchForPlayerProximity(sender)
         if UnitInParty(sender) then
             if Utils.isPlayerWithinRange(sender, Config.Settings.distanceInferringClose) then
                 if not flagProximityReached then
-                    print("|cff87CEEB[Thic-Portals]|r " .. sender .. " is nearby and might be taking the portal.")
+                    Utils.print(sender .. " is nearby and might be taking the portal.")
                     flagProximityReached = true
                 end
             elseif flagProximityReached and
                 not Utils.isPlayerWithinRange(sender, Config.Settings.distanceInferringTravelled) then
-                if Config.Settings.debugMode then
-                    print("|cff87CEEB[Thic-Portals]|r " .. sender .. " has moved away, assuming they took the portal.")
-                end
+                Utils.debugPrint(sender .. " has moved away, assuming they took the portal.")
 
                 if Events.pendingInvites[sender] then
                     Events.pendingInvites[sender].travelled = true
@@ -297,15 +271,14 @@ end
 
 -- Function to check if there was a tip in the trade
 function InviteTrade.checkTradeTip()
-    print("|cff87CEEB[Thic-Portals]|r Checking trade tip...");
+    Utils.print("Checking trade tip...");
 
     local copper = tonumber(Config.currentTraderMoney);
     local silver = math.floor((copper % 10000) / 100);
     local gold = math.floor(copper / 10000);
     local remainingCopper = copper % 100;
 
-    print(
-        string.format("|cff87CEEB[Thic-Portals]|r Received %dg %ds %dc from the trade.", gold, silver, remainingCopper));
+    Utils.print(string.format("Received %dg %ds %dc from the trade.", gold, silver, remainingCopper));
 
     if gold > 0 or silver > 0 or remainingCopper > 0 then
         Utils.incrementTradesCompleted();
@@ -368,8 +341,7 @@ function InviteTrade.sendFoodAndWaterStockMessage(playerName, playerClass)
     -- If the player has no food or water in their inventory, we will not advertise it
     if not foodStock and not waterStock then
         -- Print a warning to the player that they're out of stock
-        print(
-            "|cff87CEEB[Thic-Portals]|r You have run out of food and water stock. Please restock or disable food and water support.")
+        Utils.print("You have run out of food and water stock. Please restock or disable food and water support.")
         return
     end
 
@@ -382,10 +354,8 @@ function InviteTrade.sendFoodAndWaterStockMessage(playerName, playerClass)
     end
 
     -- if debug mode log both food and water stock
-    if Config.Settings.debugMode then
-        print("|cff87CEEB[Thic-Portals]|r Food stock: " .. (foodStock or "none"))
-        print("|cff87CEEB[Thic-Portals]|r Water stock: " .. (waterStock or "none"))
-    end
+    Utils.debugPrint("Food stock: " .. (foodStock or "none"))
+    Utils.debugPrint("Water stock: " .. (waterStock or "none"))
 
     if targetIsManaUser then
         if waterStock and foodStock then

--- a/ThicPortals.lua
+++ b/ThicPortals.lua
@@ -34,30 +34,30 @@ function handleCommand(msg)
 
     if command == "on" then
         Config.Settings.addonEnabled = true
-        print("|cff87CEEB[Thic-Portals]|r Addon enabled.")
+        Utils.print("Addon enabled.")
         UI.addonEnabledCheckbox:SetValue(true)
     elseif command == "off" then
         Config.Settings.addonEnabled = false
-        print("|cff87CEEB[Thic-Portals]|r Addon disabled.")
+        Utils.print("Addon disabled.")
         UI.addonEnabledCheckbox:SetValue(false)
     elseif command == "show" then
         UI.showToggleButton()
-        print("|cff87CEEB[Thic-Portals]|r Addon management icon displayed.")
+        Utils.print("Addon management icon displayed.")
     elseif command == "reset" then
         UI.resetToggleButtonPosition()
-        print("|cff87CEEB[Thic-Portals]|r Addon management icon position reset.")
+        Utils.print("Addon management icon position reset.")
     elseif command == "msg" then
         Config.Settings.inviteMessage = rest
-        print("|cff87CEEB[Thic-Portals]|r Invite message set to: " .. rest)
+        Utils.print("Invite message set to: " .. rest)
     elseif command == "debug" then
         if rest == "on" then
             Config.Settings.debugMode = true
-            print("|cff87CEEB[Thic-Portals]|r Debug mode enabled.")
+            Utils.print("Debug mode enabled.")
         elseif rest == "off" then
             Config.Settings.debugMode = false
-            print("|cff87CEEB[Thic-Portals]|r Debug mode disabled.")
+            Utils.print("Debug mode disabled.")
         else
-            print("|cff87CEEB[Thic-Portals]|r Usage: /Tp debug on/off - Enable or disable debug mode")
+            Utils.print("Usage: /Tp debug on/off - Enable or disable debug mode")
         end
     elseif command == "keywords" then
         local action, keywordType, keyword = rest:match("^(%S*)%s*(%S*)%s*(.-)$")
@@ -70,36 +70,36 @@ function handleCommand(msg)
             elseif keywordType == "service" then
                 keywordTable = Config.Settings.ServiceKeywords
             else
-                print("|cff87CEEB[Thic-Portals]|r Invalid keyword type. Use 'intent', 'destination', or 'service'.")
+                Utils.print("Invalid keyword type. Use 'intent', 'destination', or 'service'.")
                 return
             end
             if action == "add" then
                 table.insert(keywordTable, keyword)
-                print("|cff87CEEB[Thic-Portals]|r Added keyword to " .. keywordType .. ": " .. keyword)
+                Utils.print("Added keyword to " .. keywordType .. ": " .. keyword)
             elseif action == "remove" then
                 for i, k in ipairs(keywordTable) do
                     if k == keyword then
                         table.remove(keywordTable, i)
-                        print("|cff87CEEB[Thic-Portals]|r Removed keyword from " .. keywordType .. ": " .. keyword)
+                        Utils.print("Removed keyword from " .. keywordType .. ": " .. keyword)
                         break
                     end
                 end
             else
-                print("|cff87CEEB[Thic-Portals]|r Invalid action. Use 'add' or 'remove'.")
+                Utils.print("Invalid action. Use 'add' or 'remove'.")
             end
         else
-            print("|cff87CEEB[Thic-Portals]|r Usage: /Tp keywords add/remove intent/destination/service [keyword]")
+            Utils.print("Usage: /Tp keywords add/remove intent/destination/service [keyword]")
         end
     elseif command == "cooldown" then
         local seconds = tonumber(rest)
         if seconds then
             Config.Settings.inviteCooldown = seconds
-            print("|cff87CEEB[Thic-Portals]|r Invite cooldown set to " .. seconds .. " seconds.")
+            Utils.print("Invite cooldown set to " .. seconds .. " seconds.")
         else
-            print("|cff87CEEB[Thic-Portals]|r Usage: /Tp cooldown [seconds] - Set the invite cooldown period")
+            Utils.print("Usage: /Tp cooldown [seconds] - Set the invite cooldown period")
         end
     elseif command == "checkspells" then
-        print("|cff87CEEB[Thic-Portals]|r Scanning spellbook for Conjure spells...")
+        Utils.print("Scanning spellbook for Conjure spells...")
         local i = 1
         local foundFood = false
         local foundWater = false
@@ -109,7 +109,7 @@ function handleCommand(msg)
                 break
             end
             if spellName == "Conjure Food" or spellName == "Conjure Water" then
-                print("|cff87CEEB[Thic-Portals]|r Found: " .. spellName .. " (" .. (spellRank or "no rank") .. ")")
+                Utils.print("Found: " .. spellName .. " (" .. (spellRank or "no rank") .. ")")
                 if spellName == "Conjure Food" then
                     foundFood = true
                 end
@@ -120,37 +120,37 @@ function handleCommand(msg)
             i = i + 1
         end
         if not foundFood and not foundWater then
-            print("|cff87CEEB[Thic-Portals]|r No Conjure spells found in spellbook!")
+            Utils.print("No Conjure spells found in spellbook!")
         end
 
         -- Debug: Check config structure
         if not Config.Settings.foodItems then
-            print("|cff87CEEB[Thic-Portals]|r ERROR: Config.Settings.foodItems is nil!")
+            Utils.print("ERROR: Config.Settings.foodItems is nil!")
         else
-            print("|cff87CEEB[Thic-Portals]|r Config has " .. #Config.Settings.foodItems .. " food items defined.")
+            Utils.print("Config has " .. #Config.Settings.foodItems .. " food items defined.")
             if #Config.Settings.foodItems > 0 then
                 local item = Config.Settings.foodItems[1]
-                print("|cff87CEEB[Thic-Portals]|r Sample food item: name=" .. (item.name or "nil") .. ", spellName=" ..
+                Utils.print("Sample food item: name=" .. (item.name or "nil") .. ", spellName=" ..
                           (item.spellName or "nil") .. ", rank=" .. (item.rank or "nil"))
             end
         end
 
         if not Config.Settings.waterItems then
-            print("|cff87CEEB[Thic-Portals]|r ERROR: Config.Settings.waterItems is nil!")
+            Utils.print("ERROR: Config.Settings.waterItems is nil!")
         else
-            print("|cff87CEEB[Thic-Portals]|r Config has " .. #Config.Settings.waterItems .. " water items defined.")
+            Utils.print("Config has " .. #Config.Settings.waterItems .. " water items defined.")
         end
 
         local availableFood = Utils.getAvailableFoodItems()
         local availableWater = Utils.getAvailableWaterItems()
-        print("|cff87CEEB[Thic-Portals]|r Detected " .. #availableFood .. " food items and " .. #availableWater ..
+        Utils.print("Detected " .. #availableFood .. " food items and " .. #availableWater ..
                   " water items you can conjure.")
 
         -- Test the detection function directly
         local testResult = Utils.isSpellRankKnown("Conjure Food", 7)
-        print("|cff87CEEB[Thic-Portals]|r Direct test - isSpellRankKnown('Conjure Food', 7) = " .. tostring(testResult))
+        Utils.print("Direct test - isSpellRankKnown('Conjure Food', 7) = " .. tostring(testResult))
     elseif command == "help" then
-        print("|cff87CEEB[Thic-Portals]|r Usage:")
+        Utils.print("Usage:")
         print("/Tp show - Show the addon button")
         print("/Tp on - Enable the addon")
         print("/Tp off - Disable the addon")
@@ -162,9 +162,9 @@ function handleCommand(msg)
         print("/Tp keywords add/remove intent/destination/service [keyword] - Add or remove a keyword")
         print("/Tp cooldown [seconds] - Set the invite cooldown period")
     elseif command == "author" then
-        print("|cff87CEEB[Thic-Portals]|r This addon was created by [Thic-Ashbringer EU].")
+        Utils.print("This addon was created by [Thic-Ashbringer EU].")
     else
-        print("|cff87CEEB[Thic-Portals]|r Invalid command. Type /Tp help for usage instructions.")
+        Utils.print("Invalid command. Type /Tp help for usage instructions.")
     end
 end
 

--- a/UI.lua
+++ b/UI.lua
@@ -166,7 +166,7 @@ local function addPriceEditBoxes(group, category, prices)
             if prices and prices[item.name] then
                 prices[item.name] = value
             end
-            print("|cff87CEEB[Thic-Portals]|r " .. item.name .. " price updated to " .. value .. ".")
+            Utils.print("" .. item.name .. " price updated to " .. value .. ".")
         end)
         group:AddChild(priceEditBox)
     end
@@ -226,11 +226,11 @@ function UI.toggleAddonEnabledState()
     if Config.Settings.addonEnabled then
         toggleButtonOverlayTexture:SetTexture("Interface\\AddOns\\ThicPortals\\Media\\Logo\\thicportalsopen.tga") -- Replace with the path to your image
         UI.addonEnabledCheckbox:SetValue(true)
-        print("|cff87CEEB[Thic-Portals]|r The portal shop is open!")
+        Utils.print("The portal shop is open!")
     else
         toggleButtonOverlayTexture:SetTexture("Interface\\AddOns\\ThicPortals\\Media\\Logo\\thicportalsclosed.tga") -- Replace with the path to your image
         UI.addonEnabledCheckbox:SetValue(false)
-        print("|cff87CEEB[Thic-Portals]|r You closed the shop.")
+        Utils.print("You closed the shop.")
 
         -- Clear any tracked players and their data
         Events.pendingInvites = {}
@@ -270,9 +270,7 @@ function UI.createToggleButton()
             UI.toggleAddonEnabledState() -- Update the button text
         elseif button == "RightButton" then
             -- If debug mode log the current options panel state
-            if Config.Settings.debugMode then
-                print("Options Panel Hidden: " .. tostring(Config.Settings.optionsPanelHidden))
-            end
+            Utils.debugPrint("Options Panel Hidden: " .. tostring(Config.Settings.optionsPanelHidden))
 
             if Config.Settings.optionsPanelHidden then
                 UI.showOptionsPanel()
@@ -290,11 +288,9 @@ function UI.createToggleButton()
         local point, relativeTo, relativePoint, xOfs, yOfs = self:GetPoint()
 
         -- If debug mode is enabled, print the position
-        if Config.Settings.debugMode then
-            print("Icon moved to Point: " .. point)
-            print("Icon moved to X: " .. xOfs)
-            print("Icon moved to Y: " .. yOfs)
-        end
+        Utils.debugPrint("Icon moved to Point: " .. point)
+        Utils.debugPrint("Icon moved to X: " .. xOfs)
+        Utils.debugPrint("Icon moved to Y: " .. yOfs)
 
         -- Save the position in the config
         Config.Settings.toggleButtonPosition = {
@@ -356,8 +352,8 @@ function UI.setIconSpell(inviteData, destination)
     inviteData.actionButton:SetAttribute("type", "spell")
     inviteData.actionButton:SetAttribute("spell", inviteData.portal.spellName)
 
-    if Config.Settings.debugMode and inviteData.portal.matched then
-        print("Setting icon spell for " .. destination)
+    if inviteData.portal.matched then
+        Utils.debugPrint("Setting icon spell for " .. destination)
     end
 
     -- Set the icon texture for the portal spell
@@ -366,9 +362,7 @@ end
 
 function UI.setTradeIcon(inviteData)
     -- If debug, log the action
-    if Config.Settings.debugMode then
-        print("Setting trade icon for " .. inviteData.name)
-    end
+    Utils.debugPrint("Setting trade icon for " .. inviteData.name)
 
     if not inviteData.actionButton.icon then
         -- Create the icon texture if it doesn't exist
@@ -426,8 +420,8 @@ function UI.updateTicketList()
 
     UI.totalTickets = #UI.ticketList
 
-    if Config.Settings and Config.Settings.debugMode then
-        print("|cff87CEEB[Thic-Portals] Total ticket count updated: " .. tostring(UI.totalTickets))
+    if Config.Settings then
+        Utils.debugPrint("Total ticket count updated: " .. tostring(UI.totalTickets))
     end
 end
 
@@ -485,9 +479,9 @@ function UI.updateTicketFrame()
 
     -- Print the current alive portals
     if Config.Settings.debugMode then
-        print("|cff87CEEB[Thic-Portals] Current alive portals:")
+        Utils.debugPrint("Current alive portals:")
         for spellName, cast in pairs(Config.CurrentAlivePortals or {}) do
-            print("LIVE PORTAL: " .. spellName .. ": " .. tostring(cast))
+            Utils.debugPrint("LIVE PORTAL: " .. spellName .. ": " .. tostring(cast))
         end
     end
 
@@ -514,9 +508,7 @@ function UI.updateTicketFrame()
     removeButton:SetScript("OnClick", function()
         UninviteUnit(sender)
 
-        if Config.Settings.debugMode then
-            print("|cff87CEEB[Thic-Portals]|r " .. sender .. " has been removed from the party.")
-        end
+        Utils.debugPrint("" .. sender .. " has been removed from the party.")
 
         Events.pendingInvites[sender] = nil
 
@@ -804,9 +796,7 @@ function UI.showPaginatedTicketWindow()
 
         local function toggleMessageView()
             if not ticketFrame.viewingMessage then
-                if Config.Settings.debugMode then
-                    print("Toggling to message view")
-                end
+                Utils.debugPrint("Toggling to message view")
                 ticketFrame.viewingMessage = true
                 iconButton:SetNormalTexture("Interface\\Icons\\achievement_bg_returnxflags_def_wsg")
 
@@ -853,9 +843,7 @@ function UI.showPaginatedTicketWindow()
                     UI.ticketFrame.tickIcon:Hide()
                 end
             else
-                if Config.Settings.debugMode then
-                    print("Toggling back to original view")
-                end
+                Utils.debugPrint("Toggling back to original view")
                 ticketFrame.viewingMessage = false
                 iconButton:SetNormalTexture("Interface\\Icons\\INV_Letter_15")
 
@@ -955,12 +943,12 @@ local function createKeywordSection(scroll, titleText, keywordTable, keywordTabl
             if not Utils.keywordInTable(keyword, keywordTable) then
                 table.insert(keywordTable, keyword)
                 updateKeywordsText()
-                print("|cff87CEEB[Thic-Portals]|r " .. keyword .. " has been added.")
+                Utils.print("" .. keyword .. " has been added.")
             else -- If it already exists
-                print("|cff87CEEB[Thic-Portals]|r " .. keyword .. " is already in the list.")
+                Utils.print("" .. keyword .. " is already in the list.")
             end
         else
-            print("|cff87CEEB[Thic-Portals]|r Cannot add an empty or invalid keyword.")
+            Utils.print("Cannot add an empty or invalid keyword.")
         end
     end
 
@@ -971,12 +959,12 @@ local function createKeywordSection(scroll, titleText, keywordTable, keywordTabl
                 if k == keyword then
                     table.remove(keywordTable, i)
                     updateKeywordsText()
-                    print("|cff87CEEB[Thic-Portals]|r " .. keyword .. " has been removed.")
+                    Utils.print("" .. keyword .. " has been removed.")
                     break
                 end
             end
         else
-            print("|cff87CEEB[Thic-Portals]|r Cannot remove an empty or invalid keyword.")
+            Utils.print("Cannot remove an empty or invalid keyword.")
         end
     end
 
@@ -1126,9 +1114,9 @@ function UI.createOptionsPanel()
         Config.Settings.disableGlobalChannels, function(_, _, value)
             Config.Settings.disableGlobalChannels = value
             if Config.Settings.disableGlobalChannels then
-                print("|cff87CEEB[Thic-Portals]|r Global channels disabled.")
+                Utils.print("Global channels disabled.")
             else
-                print("|cff87CEEB[Thic-Portals]|r Global channels enabled.")
+                Utils.print("Global channels enabled.")
             end
         end, "Enables or disables the addon from listening to global channels for requests.")
 
@@ -1137,9 +1125,9 @@ function UI.createOptionsPanel()
         function(_, _, value)
             Config.Settings.ApproachMode = value
             if Config.Settings.ApproachMode then
-                print("|cff87CEEB[Thic-Portals]|r Approach mode enabled.")
+                Utils.print("Approach mode enabled.")
             else
-                print("|cff87CEEB[Thic-Portals]|r Approach mode disabled.")
+                Utils.print("Approach mode disabled.")
             end
         end, "When enabled, the addon will require only a destination value to be provided in either a say/whisper.")
 
@@ -1148,9 +1136,9 @@ function UI.createOptionsPanel()
         Config.Settings.enableFoodWaterSupport, function(_, _, value)
             Config.Settings.enableFoodWaterSupport = value
             if Config.Settings.enableFoodWaterSupport then
-                print("|cff87CEEB[Thic-Portals]|r Food and Water support enabled.")
+                Utils.print("Food and Water support enabled.")
             else
-                print("|cff87CEEB[Thic-Portals]|r Food and Water support disabled.")
+                Utils.print("Food and Water support disabled.")
             end
         end,
         "Enables or disables the ability to sell food and water items through the portal service. Food and water will be advertised to relevant customers depending on stock levels.")
@@ -1160,9 +1148,9 @@ function UI.createOptionsPanel()
         Config.Settings.disableSmartMatching, function(_, _, value)
             Config.Settings.disableSmartMatching = value
             if Config.Settings.disableSmartMatching then
-                print("|cff87CEEB[Thic-Portals]|r Smart matching disabled.")
+                Utils.print("Smart matching disabled.")
             else
-                print("|cff87CEEB[Thic-Portals]|r Smart matching enabled.")
+                Utils.print("Smart matching enabled.")
             end
         end,
         "Disables advanced smart matching algorithms and only uses the predefined common phrases to match requests (configurable below).")
@@ -1172,9 +1160,9 @@ function UI.createOptionsPanel()
         function(_, _, value)
             Config.Settings.requireDestination = value
             if Config.Settings.requireDestination then
-                print("|cff87CEEB[Thic-Portals]|r Require destination enabled.")
+                Utils.print("Require destination enabled.")
             else
-                print("|cff87CEEB[Thic-Portals]|r Require destination disabled.")
+                Utils.print("Require destination disabled.")
             end
         end,
         "When enabled, the addon will require a valid destination (one listed in Destination Keywords) in the message before sending out the invite.")
@@ -1184,9 +1172,9 @@ function UI.createOptionsPanel()
         Config.Settings.removeRealmFromInviteCommand, function(_, _, value)
             Config.Settings.removeRealmFromInviteCommand = value
             if Config.Settings.removeRealmFromInviteCommand then
-                print("|cff87CEEB[Thic-Portals]|r Smart matching disabled.")
+                Utils.print("Smart matching disabled.")
             else
-                print("|cff87CEEB[Thic-Portals]|r Smart matching enabled.")
+                Utils.print("Smart matching enabled.")
             end
         end,
         "When enabled, removes the realm name e.g. '-Ashbringer' from invite commands, making invites suitable for certain single realm servers.")
@@ -1196,9 +1184,9 @@ function UI.createOptionsPanel()
         Config.Settings.disableAFKProtection, function(_, _, value)
             Config.Settings.disableAFKProtection = value
             if Config.Settings.disableAFKProtection then
-                print("|cff87CEEB[Thic-Portals]|r AFK protection disabled.")
+                Utils.print("AFK protection disabled.")
             else
-                print("|cff87CEEB[Thic-Portals]|r AFK protection enabled.")
+                Utils.print("AFK protection enabled.")
             end
         end,
         "Disables the AFK protection feature which is in place to prevent potentially over-inviting players if the user forgets the addon is running. Two players in a row leaving the party without payment triggers shop close.")
@@ -1207,10 +1195,10 @@ function UI.createOptionsPanel()
     addCheckbox(checkboxGroup, "Hide Icon", UI.hideIconCheckbox, Config.Settings.hideIcon, function(_, _, value)
         Config.Settings.hideIcon = value
         if Config.Settings.hideIcon then
-            print("|cff87CEEB[Thic-Portals]|r Open/Closed icon marked visible.")
+            Utils.print("Open/Closed icon marked visible.")
             toggleButton:Hide()
         else
-            print("|cff87CEEB[Thic-Portals]|r Open/Closed icon marked hidden.")
+            Utils.print("Open/Closed icon marked hidden.")
             toggleButton:Show()
         end
     end, "Hides or shows the toggle button on the screen. You can use '/Tp show' to reveal the hidden icon again.")
@@ -1220,9 +1208,9 @@ function UI.createOptionsPanel()
         function(_, _, value)
             Config.Settings.soundEnabled = value
             if Config.Settings.soundEnabled then
-                print("|cff87CEEB[Thic-Portals]|r Sound enabled.")
+                Utils.print("Sound enabled.")
             else
-                print("|cff87CEEB[Thic-Portals]|r Sound disabled.")
+                Utils.print("Sound disabled.")
             end
         end, "Enables or disables sound notifications.")
 
@@ -1231,9 +1219,9 @@ function UI.createOptionsPanel()
         function(_, _, value)
             Config.Settings.debugMode = value
             if Config.Settings.debugMode then
-                print("|cff87CEEB[Thic-Portals]|r Debug mode enabled.")
+                Utils.print("Debug mode enabled.")
             else
-                print("|cff87CEEB[Thic-Portals]|r Debug mode disabled.")
+                Utils.print("Debug mode disabled.")
             end
         end, "Toggles debug mode for additional console logging.")
 
@@ -1258,10 +1246,10 @@ function UI.createOptionsPanel()
         local value = tonumber(text)
         if value and value >= 1 and value <= 15 then
             Config.Settings.maxSimultaneousTickets = math.floor(value)
-            print("|cff87CEEB[Thic-Portals]|r Max simultaneous tickets set to: " ..
+            Utils.print("Max simultaneous tickets set to: " ..
                       Config.Settings.maxSimultaneousTickets)
         else
-            print("|cff87CEEB[Thic-Portals]|r Invalid value. Please enter a number between 1 and 15.")
+            Utils.print("Invalid value. Please enter a number between 1 and 15.")
             widget:SetText(tostring(Config.Settings.maxSimultaneousTickets))
         end
     end)
@@ -1347,7 +1335,7 @@ function UI.createOptionsPanel()
     local inviteMessageGroup = addMessageMultiLineEditBox("Invite Message:", Config.Settings.inviteMessage,
         function(text)
             Config.Settings.inviteMessage = text
-            print("|cff87CEEB[Thic-Portals]|r Invite message updated.")
+            Utils.print("Invite message updated.")
         end)
     messageConfigGroup:AddChild(inviteMessageGroup)
     messageConfigGroup:AddChild(smallVerticalGap)
@@ -1356,7 +1344,7 @@ function UI.createOptionsPanel()
     local inviteMessageWithoutDestinationGroup = addMessageMultiLineEditBox("Invite Message (No Destination):",
         Config.Settings.inviteMessageWithoutDestination, function(text)
             Config.Settings.inviteMessageWithoutDestination = text
-            print("|cff87CEEB[Thic-Portals]|r Invite message without destination updated.")
+            Utils.print("Invite message without destination updated.")
         end)
     messageConfigGroup:AddChild(inviteMessageWithoutDestinationGroup)
     messageConfigGroup:AddChild(smallVerticalGap)
@@ -1364,7 +1352,7 @@ function UI.createOptionsPanel()
     -- Tip Message
     local tipMessageGroup = addMessageMultiLineEditBox("Tip Message:", Config.Settings.tipMessage, function(text)
         Config.Settings.tipMessage = text
-        print("|cff87CEEB[Thic-Portals]|r Tip message updated.")
+        Utils.print("Tip message updated.")
     end)
     messageConfigGroup:AddChild(tipMessageGroup)
     messageConfigGroup:AddChild(smallVerticalGap)
@@ -1372,7 +1360,7 @@ function UI.createOptionsPanel()
     -- No Tip Message
     local noTipMessageGroup = addMessageMultiLineEditBox("No Tip Message:", Config.Settings.noTipMessage, function(text)
         Config.Settings.noTipMessage = text
-        print("|cff87CEEB[Thic-Portals]|r No tip message updated.")
+        Utils.print("No tip message updated.")
     end)
     messageConfigGroup:AddChild(noTipMessageGroup)
     messageConfigGroup:AddChild(largeVerticalGap)
@@ -1407,9 +1395,7 @@ end
 -- Show the options panel
 function UI.showOptionsPanel()
     -- If debug mode is enabled, print a message
-    if Config.Settings.debugMode then
-        print("|cff87CEEB[Thic-Portals]|r Showing options panel.")
-    end
+    Utils.debugPrint("Showing options panel.")
 
     if not optionsPanel then
         UI.createOptionsPanel()
@@ -1425,9 +1411,7 @@ end
 -- Hide the options panel
 function UI.hideOptionsPanel()
     -- If debug mode is enabled, print a message
-    if Config.Settings.debugMode then
-        print("|cff87CEEB[Thic-Portals]|r Hiding options panel.")
-    end
+    Utils.debugPrint("Hiding options panel.")
 
     if optionsPanel then
         optionsPanel:Hide()
@@ -1501,7 +1485,7 @@ function UI.createInterfaceOptionsPanel()
     showIconButton:SetText("Show Icon Button")
     showIconButton:SetScript("OnClick", function()
         UI.showToggleButton()
-        print("|cff87CEEB[Thic-Portals]|r Addon management icon displayed.")
+        Utils.print("Addon management icon displayed.")
     end)
 
     -- Reset Icon Position Button
@@ -1511,7 +1495,7 @@ function UI.createInterfaceOptionsPanel()
     resetIconButton:SetText("Reset Icon Position")
     resetIconButton:SetScript("OnClick", function()
         UI.resetToggleButtonPosition()
-        print("|cff87CEEB[Thic-Portals]|r Addon management icon position reset.")
+        Utils.print("Addon management icon position reset.")
     end)
 
     -- Add descriptions for the buttons

--- a/Utils.lua
+++ b/Utils.lua
@@ -123,11 +123,11 @@ end
 
 -- Function to print gold information
 function Utils.printGoldInformation()
-    print(string.format("|cff87CEEB[Thic-Portals]|r Total trades completed: %d", Config.Settings.totalTradesCompleted))
-    print(string.format("|cff87CEEB[Thic-Portals]|r Total gold earned: %dg %ds %dc",
+    Utils.print(string.format("Total trades completed: %d", Config.Settings.totalTradesCompleted))
+    Utils.print(string.format("Total gold earned: %dg %ds %dc",
         math.floor(Config.Settings.totalGold / 10000), math.floor((Config.Settings.totalGold % 10000) / 100),
         Config.Settings.totalGold % 100))
-    print(string.format("|cff87CEEB[Thic-Portals]|r Gold earned today: %dg %ds %dc",
+    Utils.print(string.format("Gold earned today: %dg %ds %dc",
         math.floor(Config.Settings.dailyGold / 10000), math.floor((Config.Settings.dailyGold % 10000) / 100),
         Config.Settings.dailyGold % 100))
 end
@@ -138,7 +138,7 @@ function Utils.resetDailyGoldIfNeeded()
     if Config.Settings.lastUpdateDate ~= currentDate then
         Config.Settings.dailyGold = 0
         Config.Settings.lastUpdateDate = currentDate
-        print("|cff87CEEB[Thic-Portals]|r Daily gold counter reset for a new day.")
+        Utils.print("Daily gold counter reset for a new day.")
     end
 end
 
@@ -223,9 +223,7 @@ function Utils.getMatchingPortal(destination)
     end
 
     if bestMatch then
-        if Config.Settings.debugMode then
-            print("Best match for destination: " .. bestMatch)
-        end
+        Utils.debugPrint("Best match for destination: " .. bestMatch)
 
         local spellID = nil
 
@@ -385,6 +383,16 @@ function Utils.getHighestTierWaterInInventory()
         end
     end
     return nil, 0
+end
+
+function Utils.print(message)
+    print("|cff87CEEB[Thic-Portals]|r " .. message)
+end
+
+function Utils.debugPrint(message)
+    if Config.Settings.debugMode then
+        Utils.print(message)
+    end
 end
 
 _G.Utils = Utils


### PR DESCRIPTION
While working on the addon I noticed that there is a lot of repetition in the print statements always having the "[Thic-portals]" colored prefix hardcoded. This causes you to pretty much always have to copy/paste an existing print statement.

Additionally, there are a lot of blocks like:

```
if Config.Settings.debugMode then
  print(...)
end
```

To make this a bit cleaner throughout the codebase, I added a `Utils.print()` and `Utils.debugPrint()` function that automatically and consistently adds the prefix to any printed messages and embed the debug mode check in one place.

Not really anything that end users are going to notice, but I think it's a nice cleanup/quality of life update of the codebase for people that work on the addon.