### PR TITLE
Make keyword labels interactive

### DIFF
--- a/ThicPortals.toc
+++ b/ThicPortals.toc
@@ -2,7 +2,7 @@
 ## Title: Thic-Portals
 ## Notes: Automatically invites players who request a portal and sends them a whisper asking for their desired destination if not specified.
 ## Author: Thic-Ashbringer EU
-## Version: 3.4.2
+## Version: 3.4.3
 ## SavedVariables: ThicPortalSettings, ThicPortalsSaved, BanList, IntentKeywords, DestinationKeywords, ServiceKeywords, InviteMessage, InviteMessageWithoutDestination, TipMessage, NoTipMessage, HideIcon, ApproachMode
 
 # Embeds

--- a/UI.lua
+++ b/UI.lua
@@ -921,14 +921,20 @@ end
 local function createKeywordSection(scroll, titleText, keywordTable, keywordTableType, description)
     local userListGroup = AceGUI:Create("InlineGroup")
     local userListContent = AceGUI:Create("SimpleGroup")
-    local keywordsText = AceGUI:Create("Label")
+    local editBox = AceGUI:Create("EditBox")
 
     local function updateKeywordsText()
-        local text = ""
-        for _, keyword in ipairs(keywordTable) do
-            text = text .. keyword .. "\n"
+        userListContent:ReleaseChildren() -- Clear existing content
+
+        local labels = {}
+        for i, keyword in ipairs(keywordTable) do
+            labels[i] = AceGUI:Create("InteractiveLabel")
+            labels[i]:SetText(keyword)
+            labels[i]:SetCallback("OnEnter", function(label) label:SetColor(1, 0.75, 0) end) -- Highlight on hover
+            labels[i]:SetCallback("OnLeave", function(label) label:SetColor(1, 1, 1) end) -- Reset color when not hovering
+            labels[i]:SetCallback("OnClick", function() editBox:SetText(keyword) end)
+            userListContent:AddChild(labels[i])
         end
-        keywordsText:SetText(text)
 
         -- Ensure the layout is updated when content changes
         userListContent:DoLayout()
@@ -991,7 +997,6 @@ local function createKeywordSection(scroll, titleText, keywordTable, keywordTabl
     scroll:AddChild(keywordGroup)
 
     -- Add/Remove Keyword MultiLineEditBox
-    local editBox = AceGUI:Create("EditBox")
     editBox:SetLabel("Add/Remove " .. (keywordTableType or "Keyword")) -- Use the passed keywordTableType or default to "Keyword"
     editBox:SetWidth(200)
     editBox:DisableButton(true)
@@ -1041,10 +1046,7 @@ local function createKeywordSection(scroll, titleText, keywordTable, keywordTabl
     userListContent:SetAutoAdjustHeight(true) -- Adjust height automatically
     userListGroup:AddChild(userListContent)
 
-    -- Keywords Text Label
-    keywordsText:SetFullWidth(true)
-    userListContent:AddChild(keywordsText)
-
+    -- Initial population of keywords
     updateKeywordsText()
 end
 
@@ -1364,6 +1366,12 @@ function UI.createOptionsPanel()
     end)
     messageConfigGroup:AddChild(noTipMessageGroup)
     messageConfigGroup:AddChild(largeVerticalGap)
+
+    -- Short delay to ensure the UI is ready before we attempt to populate the keyword sections
+    repeat
+        C_Timer.After(1, function() end)
+        Utils.debugPrint("Waiting for UI to initialize before populating keyword sections...")
+    until Events.uiInitialized
 
     -- Creating Keyword Sections
     createKeywordSection(scroll, "|cFFFFD700Any Keyword Ban List Management|r", Config.Settings.KeywordBanList,

--- a/UI.lua
+++ b/UI.lua
@@ -926,14 +926,13 @@ local function createKeywordSection(scroll, titleText, keywordTable, keywordTabl
     local function updateKeywordsText()
         userListContent:ReleaseChildren() -- Clear existing content
 
-        local labels = {}
-        for i, keyword in ipairs(keywordTable) do
-            labels[i] = AceGUI:Create("InteractiveLabel")
-            labels[i]:SetText(keyword)
-            labels[i]:SetCallback("OnEnter", function(label) label:SetColor(1, 0.75, 0) end) -- Highlight on hover
-            labels[i]:SetCallback("OnLeave", function(label) label:SetColor(1, 1, 1) end) -- Reset color when not hovering
-            labels[i]:SetCallback("OnClick", function() editBox:SetText(keyword) end)
-            userListContent:AddChild(labels[i])
+        for _, keyword in ipairs(keywordTable) do
+            local label = AceGUI:Create("InteractiveLabel")
+            label:SetText(keyword)
+            label:SetCallback("OnEnter", function(label) label:SetColor(1, 0.75, 0) end) -- Highlight on hover
+            label:SetCallback("OnLeave", function(label) label:SetColor(1, 1, 1) end) -- Reset color when not hovering
+            label:SetCallback("OnClick", function() editBox:SetText(keyword) end)
+            userListContent:AddChild(label)
         end
 
         -- Ensure the layout is updated when content changes


### PR DESCRIPTION
Currently, the removing of existing keywords is a bit tedious as you have to re-type the word that you want to remove.

So I updated the `createKeywordSection` to use a set of `InteractiveLabel` widgets instead of one huge label with newlines.

By making them interactive:

- Keywords can be clicked to pre-fill them in the edit box
- Keywords are highlighted on hover

While testing this I also got some UI errors. It looks like the addon was trying to create the keyword sections before the UI was initialized. I suppose this was not an issue when it was still "plain-text", but now that we introduce an interactive element, it caused the errors to show. To avoid this from happening, I added a `repeat (...) until Events.uiInitialized` into the `UI.createOptionsPanel` function just before we create the keyword sections and this seems to work as intended without throwing any more UI errors.

Here's a quick demo video of the changes in action:

https://github.com/user-attachments/assets/c3967ec1-982a-4dd6-bf73-a3297636c86c


